### PR TITLE
Make the links more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,5 +254,5 @@ See also http://github.com/monora/rgl/contributors.
 ## Copying
 
 RGL is Copyright (c) 2002,2004,2005,2008,2013,2015,2019 by Horst Duchene. It is
-free software, and may be redistributed under the license and terms specified in the
-README file of the Ruby distribution.
+free software, and may be redistributed under the [Ruby license](https://en.wikipedia.org/wiki/Ruby_License) and terms specified in the
+[COPYING](https://github.com/ruby/ruby/blob/master/COPYING) file of the Ruby language distribution.


### PR DESCRIPTION
When I first read this sentence, I thought "the Ruby distribution" meant "the Ruby distribution of rgl", and then got very confused.

Makes the sentence more explicit and link to the correct file.